### PR TITLE
Fixed UnicodeEncodeError for non-ASCII symbols in servel model

### DIFF
--- a/hetznerctl
+++ b/hetznerctl
@@ -153,7 +153,7 @@ class ListServers(Options):
         for server in robot.servers:
             info = {
                 'id': server.number,
-                'model': server.product
+                'model': server.product.encode("latin1", "ignore")
             }
 
             if server.name != "":


### PR DESCRIPTION
Fixing the following error for the server model with UTF-8 symbols, like "DELL PowerEdge™ R720":

`Traceback (most recent call last):
  File "./hetznerctl", line 261, in <module>
    Main()
  File "./hetznerctl", line 60, in __init__
    cmd(argv, self)
  File "./hetznerctl", line 52, in __init__
    self.execute()
  File "./hetznerctl", line 156, in execute
    'model': server.product.encode("latin1")
UnicodeEncodeError: 'latin-1' codec can't encode character u'\u2122' in position 14: ordinal not in range(256)`
