### PR TITLE
Do not fail printing non-ascii text

### DIFF
--- a/hetznerctl
+++ b/hetznerctl
@@ -165,10 +165,10 @@ class ListServers(Options):
             if server.name != "":
                 info['name'] = server.name
 
-            infolist = ["{0}: {1}".format(key, val)
+            infolist = [u"{0}: {1}".format(key, val)
                         for key, val in info.iteritems()]
 
-            print("{0} ({1})".format(server.ip, ", ".join(infolist)))
+            print(u"{0} ({1})".format(server.ip, u", ".join(infolist)))
 
 
 class ShowServer(Options):


### PR DESCRIPTION
hetznerctl doesn't handle text in unicode under python2

```
$ hetznerctl show 88.198.xxx.xxx
Number:        32nnnnn
Main IP:       88.198.xxx.xxx
Name:          controller
Traceback (most recent call last):
  File "/home/daniel/envs/hz/bin/hetznerctl", line 10, in <module>
    execfile(__file__)
  File "/home/daniel/src/hetzner/hetznerctl", line 305, in <module>
    Main()
  File "/home/daniel/src/hetzner/hetznerctl", line 66, in __init__
    map(lambda x: x(argv, self), matches)
  File "/home/daniel/src/hetzner/hetznerctl", line 66, in <lambda>
    map(lambda x: x(argv, self), matches)
  File "/home/daniel/src/hetzner/hetznerctl", line 53, in __init__
    self.execute()
  File "/home/daniel/src/hetzner/hetznerctl", line 183, in execute
    self.print_serverinfo(robot.servers.get(ip))
  File "/home/daniel/src/hetzner/hetznerctl", line 204, in print_serverinfo
    self.print_line(key, val)
  File "/home/daniel/src/hetzner/hetznerctl", line 186, in print_line
    print("{0:<15}{1}".format(key + ":", val))
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2122' in position 14: ordinal not in range(128)
```

after this change it works:

```
$ hetznerctl show 88.198.xxx.xxx
Number:        32nnnn
Main IP:       88.198.xxx.xxx
Name:          controller
Product:       DELL PowerEdge™ R720 DX150
Data center:   2
Traffic:       30 TB
Flatrate:      True
Status:        ready
Throttled:     False
Cancelled:     False
Paid until:    2014-05-03 00:00:00
IP address:    88.198.xxx.xxx
IP address:    88.198.xxx.xxx
Subnet:        xxxx:xxxx:xxxx:xxxx::/64 (IPv6)
Gateway:       fe80::1
```
