### PR TITLE
Fixes encoding problem with DELL Servers

### DIFF
--- a/hetznerctl
+++ b/hetznerctl
@@ -183,7 +183,7 @@ class ShowServer(Options):
             self.print_serverinfo(robot.servers.get(ip))
 
     def print_line(self, key, val):
-        print("{0:<15}{1}".format(key + ":", val))
+        print(u"{0:<15}{1}".format(key + u":", val).encode("utf-8"))
 
     def print_serverinfo(self, server):
         info = [


### PR DESCRIPTION
DELL servers have a "product" field with a symbol that is not ASCII, so it gives an exception trying to show this line.
