### PR TITLE
Reboot via ssh when DELL server is detected

### DIFF
--- a/hetzner/server.py
+++ b/hetzner/server.py
@@ -444,7 +444,8 @@ class Server(object):
 
         for mode in tries:
             print("Rebooting mode: {0}".format(mode))
-            self.reboot(mode)
+            if not self.reboot(mode):
+                continue
 
             sys.stdout.write("Waiting for the server to come back")
             sys.stdout.flush()
@@ -488,6 +489,7 @@ class Server(object):
                     self.shell(None, cmdline="reboot")
                 except Exception, ex:
                     print ex
+                    return False
 
                 return True
             elif mode == "rac":

--- a/hetzner/server.py
+++ b/hetzner/server.py
@@ -432,9 +432,9 @@ class Server(object):
 
         if tries is None:
             if self.is_dell:
-                tries = ['ssh']
+                tries = ['ssh', 'rac']
 
-                # These servers take more than 5 minutes to reboot
+                # These servers take more than 5 minutes to reboot.
                 if patience <= 300:
                     patience = 600
             elif self.is_vserver:
@@ -481,12 +481,28 @@ class Server(object):
         """
 
         if self.is_dell:
+            if mode == "ssh":
+                # XXX: Warning, this only works for linux/unix systems.
+
+                try:
+                    self.shell(None, cmdline="reboot")
+                except Exception, ex:
+                    print ex
+
+                return True
+            elif mode == "rac":
+                try:
+                    ips = list(self.ips)
+                    ip = ips[1].ip
+                except:
+                    ip = ""
+
+                rac = RAC(ip)
+                rac.powercycle()
+
+                return True
             if mode != "ssh":
                 raise RobotError("DELL servers don't allow reboot via robot.")
-
-            # XXX: Warning, this only works for linux/unix systems.
-            self.shell(None, cmdline="reboot")
-            return True
 
         if self.is_vserver:
             if mode == 'soft':
@@ -533,3 +549,64 @@ class Server(object):
 
     def __repr__(self):
         return "<{0} (#{1} {2})>".format(self.ip, self.number, self.product)
+
+
+# Code got from https://github.com/migrantgeek/python-rac
+
+class RAC(object):
+
+    def __init__(self, host):
+        import getpass
+        self.sid = None
+
+        self.host = raw_input("IP of the iDRAC console [{0}]:".format(host)) or host
+        self.username = raw_input("Username [root]:") or "root"
+        self.password = getpass.getpass("Password:")
+
+    def _inject_header(self, data):
+        if data is not None:
+            return "<?xml version='1.0'?>" + data
+
+    def _extract_value(self, data, value):
+        if data is None:
+            return
+        try:
+            return data.split('<%s>' % value)[1].split('</%s>' % value)[0]
+        except KeyError:
+            raise Exception('unable to extract %s' % value)
+
+    def _extract_sid(self, data):
+        return self._extract_value(data, 'SID')
+
+    def _extract_cmd_output(self, data):
+        return self._extract_value(data, 'CMDOUTPUT')
+
+    def _make_request(self, uri, data=None):
+        import urllib2
+
+        opener = urllib2.build_opener()
+        if self.sid:
+            opener.addheaders.append(('Cookie', 'sid=%s' % self.sid))
+        return opener.open('https://%s/cgi-bin/%s' % (self.host, uri),
+                self._inject_header(data)).read()
+
+    def _login(self):
+        data = '<LOGIN><REQ><USERNAME>%s</USERNAME><PASSWORD>%s</PASSWORD></REQ></LOGIN>' % (self.username, self.password)
+        resp = self._make_request('/login', data)
+        self.sid = self._extract_sid(resp)
+
+    def _logout(self):
+        self.sid = None
+        self._make_request('/logout')
+
+    def run_command(self, cmd):
+        if self.sid is None:
+            self._login()
+        try:
+            data = '<EXEC><REQ><CMDINPUT>racadm %s</CMDINPUT><MAXOUTPUTLEN>0x0fff</MAXOUTPUTLEN></REQ></EXEC>' % cmd
+            return self._extract_cmd_output(self._make_request('/exec', data)).strip()
+        finally:
+            self._logout()
+
+    def powercycle(self):
+        return self.run_command('serveraction powercycle')

--- a/hetznerctl
+++ b/hetznerctl
@@ -78,7 +78,8 @@ class Reboot(Options):
     usage = "%prog ip..."
     option_list = [
         make_option('-m', '--method', dest='method',
-                    choices=['soft', 'hard', 'manual'], default='soft',
+                    choices=['soft', 'hard', 'manual', 'ssh', 'rac'],
+                    default='soft',
                     help="The method to use for the reboot"
                          " (Default: %default).")
     ]


### PR DESCRIPTION
I had to move the shell function to the Server class, to be able to use it from itself.

This code is working fine with DELL servers, I've tested it a couple of times.

Also, I've added a 'debug' dot while you are waiting for the server to reboot, you can throw it away, or maybe leave only when some flag is used. It's useful when you are working remotely and don't know if you're waiting or your ssh session is dead.

NOTE1: We can do some tests now because we're setting up new servers and they are not online yet.
NOTE2: I was not able to test if everything is still working on the non-dell servers cause all ours are in production now.
