### PR TITLE
hetznerctl: Add config parser for _cmd options

### DIFF
--- a/hetznerctl
+++ b/hetznerctl
@@ -3,6 +3,7 @@ import sys
 import locale
 import warnings
 import argparse
+import subprocess
 
 from os.path import expanduser
 
@@ -14,6 +15,37 @@ try:
     from ConfigParser import RawConfigParser
 except ImportError:
     from configparser import RawConfigParser
+
+
+class SecureConfigParser(RawConfigParser):
+    """A config parser extension to read *_cmd options trasperantly.
+
+    If an option is queried with get() or has_option() but it does not exist
+    this class tries to find a corresponing *_cmd option instead and execute
+    it in a shell.  The stdout of the shell command is returned as the config
+    value.
+    """
+
+    @staticmethod
+    def _run_cmd(cmd):
+        result = subprocess.run(cmd, capture_output=True)
+        if result.returncode == 0:
+            return result.stdout
+        raise Exception("Command {} exited with error {}: {}".format(cmd,
+            result.returncode, result.stderr))
+
+    def has_option(self, section, name):
+        has = lambda name: super().has_option(section, name)
+        if name.endswith("_cmd"):
+            return has(name)
+        return has(name) or has(name+"_cmd")
+
+    def get(self, section, name):
+        has = lambda name: super().has_option(section, name)
+        get = lambda name: super().get(section, name)
+        if has(name+"_cmd") and not has(name):
+            return self._run_cmd(get(name+"_cmd"))
+        return get(name)
 
 
 def make_option(*args, **kwargs):
@@ -28,7 +60,7 @@ class SubCommand(object):
     requires_robot = True
 
     def __init__(self, configfile):
-        self.config = RawConfigParser()
+        self.config = SecureConfigParser()
         self.config.read(configfile)
 
     def putline(self, line):


### PR DESCRIPTION
This wraps the config parser class from the stdlib to transparently fall back to a *_cmd option if an option is not set.  The *_cmd option is expected to be a string to be passed to the python subprocess module.  The return value of the that is the option value that is returned.

# open questions
- What python versions should be supported? Currently the code requires py3.7
- How should errors when executing a command be treated/reported? Currently an exception is thrown.
- Should the _cmd option be interpreted by the shell or as a plain command? I would prefer shell.