### PR TITLE
[Feature] added authorized_key arg to rescue command

### DIFF
--- a/hetzner/server.py
+++ b/hetzner/server.py
@@ -111,7 +111,7 @@ class RescueSystem(object):
         if not self.active:
             opts = {'os': os, 'arch': bits}
             if authorized_keys is not None:
-                opts['authorized_key'] = authorized_keys.split()
+                opts['authorized_key'] = list(authorized_keys)
             return self._rescue_action('post', opts)
 
     def deactivate(self):

--- a/hetzner/server.py
+++ b/hetzner/server.py
@@ -111,7 +111,7 @@ class RescueSystem(object):
         if not self.active:
             opts = {'os': os, 'arch': bits}
             if authorized_keys is not None:
-                opts['authorized_key'] = list(authorized_keys)
+                opts['authorized_key'] = authorized_keys.split()
             return self._rescue_action('post', opts)
 
     def deactivate(self):
@@ -126,7 +126,8 @@ class RescueSystem(object):
         Activate the rescue system and reboot into it.
         Look at Server.observed_reboot() for options.
         """
-        self.activate()
+        authkey = kwargs.pop('authkey', None)
+        self.activate(authorized_keys=authkey)
         self.server.observed_reboot(*args, **kwargs)
 
     def observed_deactivate(self, *args, **kwargs):

--- a/hetznerctl
+++ b/hetznerctl
@@ -79,9 +79,10 @@ class Rescue(SubCommand):
         make_option('-n', '--noshell', dest='noshell', action='store_true',
                     default=False, help=("Don't drop into a shell, only print"
                                          " rescue password")),
-        make_option('-a', '--authorized-key', dest='authkey', metavar='AUTHKEY',
-                    default=None, help=("md5 fingerprint of the key that should"
-                                        " have been added to robot already")),
+        make_option('-a', '--authorized-key', dest='authkey',
+                    metavar='AUTHKEY', nargs=1,
+                    help=("md5 fingerprint of the key that should"
+                          " have been added to robot already")),
         make_option('ip', metavar='IP', nargs='+',
                     help="IP address of the server to put into rescue system"),
     ]

--- a/hetznerctl
+++ b/hetznerctl
@@ -79,6 +79,9 @@ class Rescue(SubCommand):
         make_option('-n', '--noshell', dest='noshell', action='store_true',
                     default=False, help=("Don't drop into a shell, only print"
                                          " rescue password")),
+        make_option('-a', '--authorized-key', dest='authkey', metavar='AUTHKEY',
+                    default=None, help=("md5 fingerprint of the key that should"
+                                        " have been added to robot already")),
         make_option('ip', metavar='IP', nargs='+',
                     help="IP address of the server to put into rescue system"),
     ]
@@ -92,6 +95,7 @@ class Rescue(SubCommand):
             kwargs = {
                 'patience': args.patience,
                 'manual': args.manual,
+                'authkey': args.authkey,
             }
 
             if args.noshell:


### PR DESCRIPTION
I've added the `--authorized-key` argument to the rescue command. Since this is already supported in the SDK/API I see no reason to skip this as a feature.

Thanks!