### PR TITLE
Server: Drop vServer

### DIFF
--- a/hetzner/reset.py
+++ b/hetzner/reset.py
@@ -77,10 +77,7 @@ class Reset(object):
         is_down = False
 
         if tries is None:
-            if self.server.is_vserver:
-                tries = ['hard']
-            else:
-                tries = ['soft', 'hard']
+            tries = ['soft', 'hard']
 
         for mode in tries:
             self.server.logger.info("Tring to reboot using the %r method.",
@@ -119,21 +116,7 @@ class Reset(object):
         Del, "hard" for triggering a hardware reset and "manual" for requesting
         a poor devil from the data center to go to your server and press the
         power button.
-
-        On a vServer, rebooting with mode="soft" is a no-op, any other value
-        results in a hard reset.
         """
-        if self.server.is_vserver:
-            if mode == 'soft':
-                return
-
-            self.conn.scraper.login(force=True)
-            baseurl = '/server/vserverCommand/id/{0}/command/reset'
-            url = baseurl.format(self.server.number)
-            response = self.conn.scraper.request(url, method='POST')
-            assert "msgbox_success" in response.read().decode('utf-8')
-            return response
-
         modes = {
             'manual': 'man',
             'hard': 'hw',

--- a/hetzner/server.py
+++ b/hetzner/server.py
@@ -459,7 +459,6 @@ class Server(object):
         self.status = data['status']
         self.cancelled = data['cancelled']
         self.paid_until = datetime.strptime(data['paid_until'], '%Y-%m-%d')
-        self.is_vserver = self.product.startswith('VQ')
 
     def observed_reboot(self, *args, **kwargs):
         msg = ("Server.observed_reboot() is deprecated. Please use"


### PR DESCRIPTION
Hetzner does not offer VQ/VX or CX server via Robot anymore (VQ/VX servers have been cancelled in 2018/2019 and CX servers have been migrated to Cloud in 2020).

Signed-off-by: Tom Siewert <tom.siewert@hetzner.com>