### PR TITLE
robot: Use robot.hetzner.com as webhost

### DIFF
--- a/hetzner/robot.py
+++ b/hetzner/robot.py
@@ -22,7 +22,7 @@ from hetzner.failover import FailoverManager
 from hetzner.util.http import ValidatedHTTPSConnection
 
 ROBOT_HOST = "robot-ws.your-server.de"
-ROBOT_WEBHOST = "robot.your-server.de"
+ROBOT_WEBHOST = "robot.hetzner.com"
 ROBOT_LOGINHOST = "accounts.hetzner.com"
 
 RE_CSRF_TOKEN = re.compile(


### PR DESCRIPTION
The migration to robot.hetzner.com has been done silently on September 26th, 2022 by Hetzner.