### PR TITLE
use reset_types func for reset type support

### DIFF
--- a/hetzner/reset.py
+++ b/hetzner/reset.py
@@ -77,7 +77,10 @@ class Reset(object):
         is_down = False
 
         if tries is None:
-            tries = ['soft', 'hard']
+            if 'sw' not in self.reset_types:
+                tries = ['hard']
+            else:
+                tries = ['soft', 'hard']
 
         for mode in tries:
             self.server.logger.info("Trying to reboot using the %r method.",

--- a/hetzner/util/http.py
+++ b/hetzner/util/http.py
@@ -63,8 +63,21 @@ class ValidatedHTTPSConnection(HTTPSConnection):
             ).encode('ascii'))
             ca_certs.flush()
             cafile = ca_certs.name
-        self.sock = ssl.wrap_socket(sock, self.key_file, self.cert_file,
-                                    cert_reqs=ssl.CERT_REQUIRED,
-                                    ca_certs=cafile)
+        #self.sock = ssl.wrap_socket(sock, self.key_file, self.cert_file,
+        #                            cert_reqs=ssl.CERT_REQUIRED,
+        #                            ca_certs=cafile)
+        context = ssl.create_default_context(cafile=cafile)
+        context.check_hostname = True
+        context.verify_mode = ssl.CERT_REQUIRED
+
+        key_file = getattr(self, 'key_file', None)
+        cert_file = getattr(self, 'cert_file', None)
+
+        if key_file and cert_file:
+            context.load_cert_chain(cert_file, key_file)
+
+        hostname = self.host
+        self.sock = context.wrap_socket(sock, server_hostname=hostname)
+
         if bundle is None:
             ca_certs.close()


### PR DESCRIPTION
I took another look at this and I can't for the life of me see why this wouldn't be a good solution to ensure the correct reset type is being used. This does a [GET on `/reset`](https://robot.hetzner.com/doc/webservice/en.html#get-reset) which does the mapping for you and uses the completely unused `reset_types` function that you've already written.