### PR TITLE
Removing deprecated parameter "arch" from "rescue" endpoint

### DIFF
--- a/hetzner/server.py
+++ b/hetzner/server.py
@@ -100,7 +100,7 @@ class RescueSystem(object):
 
         self._update_status(reply)
 
-    def activate(self, os='linux', authorized_keys=None):
+    def activate(self, bits=None, os='linux', authorized_keys=None):
         """
         Activate the rescue system if necessary.
 
@@ -108,6 +108,11 @@ class RescueSystem(object):
         e.g. ['a3:14:62:38:d1:45:35:6c:de:ad:ec:12:be:93:24:ef'] of the keys
         that should have been added to robot already.
         """
+        # Parameter Deprecation Warning - see #59 on GitHub
+        if bits is not None:
+            warnings.warn("'bits' parameter is deprecated in Hetzner API; so it is here. See #59 on GitHub.",
+                          category=DeprecationWarning)
+
         if not self.active:
             opts = {'os': os}
             if authorized_keys is not None:

--- a/hetzner/server.py
+++ b/hetzner/server.py
@@ -100,7 +100,7 @@ class RescueSystem(object):
 
         self._update_status(reply)
 
-    def activate(self, bits=64, os='linux', authorized_keys=None):
+    def activate(self, os='linux', authorized_keys=None):
         """
         Activate the rescue system if necessary.
 
@@ -109,7 +109,7 @@ class RescueSystem(object):
         that should have been added to robot already.
         """
         if not self.active:
-            opts = {'os': os, 'arch': bits}
+            opts = {'os': os}
             if authorized_keys is not None:
                 opts['authorized_key'] = list(authorized_keys)
             return self._rescue_action('post', opts)


### PR DESCRIPTION
fixes #59