### PR TITLE
Add 'power_long': 'power_long' mapping to the dictionary modes

### DIFF
--- a/hetzner/reset.py
+++ b/hetzner/reset.py
@@ -122,6 +122,7 @@ class Reset(object):
             'hard': 'hw',
             'soft': 'sw',
             'power': 'power',
+            'power_long': 'power_long',
         }
 
         modekey = modes.get(mode, modes['soft'])


### PR DESCRIPTION
This mode is available in the Hetzner API documentation: https://robot.hetzner.com/doc/webservice/en.html#get-reset-server-number