### PR TITLE
python_maint: ssl.wrap_socket removed

### DIFF
--- a/hetzner/util/http.py
+++ b/hetzner/util/http.py
@@ -63,8 +63,19 @@ class ValidatedHTTPSConnection(HTTPSConnection):
             ).encode('ascii'))
             ca_certs.flush()
             cafile = ca_certs.name
-        self.sock = ssl.wrap_socket(sock, self.key_file, self.cert_file,
-                                    cert_reqs=ssl.CERT_REQUIRED,
-                                    ca_certs=cafile)
+
+        context = ssl.create_default_context(cafile=cafile)
+        context.check_hostname = True
+        context.verify_mode = ssl.CERT_REQUIRED
+
+        key_file = getattr(self, 'key_file', None)
+        cert_file = getattr(self, 'cert_file', None)
+
+        if key_file and cert_file:
+            context.load_cert_chain(cert_file, key_file)
+
+        hostname = self.host
+        self.sock = context.wrap_socket(sock, server_hostname=hostname)
+
         if bundle is None:
             ca_certs.close()


### PR DESCRIPTION
Fixes
```
Traceback (most recent call last):
  File "./hetznerctl", line 423, in <module>
    main()
  File "./hetznerctl", line 419, in main
    subcommand.execute(robot, parser, args)
  File "./hetznerctl", line 132, in execute
    for server in robot.servers:
  File "hetzner/robot.py", line 428, in __iter__
    return iter([Server(self.conn, s) for s in self.conn.get('/server')])
                                               ^^^^^^^^^^^^^^^^^^^^^^^^
  File "hetzner/robot.py", line 405, in get
    return self.request('GET', path)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "hetzner/robot.py", line 366, in request
    response = self._request(method, path, data, headers)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "hetzner/robot.py", line 302, in _request
    self.conn.request(method.upper(), path, data, headers)
  File "/usr/lib/python3.12/http/client.py", line 1336, in request
    self._send_request(method, url, body, headers, encode_chunked)
  File "/usr/lib/python3.12/http/client.py", line 1382, in _send_request
    self.endheaders(body, encode_chunked=encode_chunked)
  File "/usr/lib/python3.12/http/client.py", line 1331, in endheaders
    self._send_output(message_body, encode_chunked=encode_chunked)
  File "/usr/lib/python3.12/http/client.py", line 1091, in _send_output
    self.send(msg)
  File "/usr/lib/python3.12/http/client.py", line 1035, in send
    self.connect()
  File "hetzner/util/http.py", line 66, in connect
    self.sock = ssl.wrap_socket(sock, self.key_file, self.cert_file,
                ^^^^^^^^^^^^^^^
AttributeError: module 'ssl' has no attribute 'wrap_socket'
```