### PR TITLE
Fix: Refactor SSL socket wrapping in ValidatedHTTPSConnection

### DIFF
--- a/hetzner/util/http.py
+++ b/hetzner/util/http.py
@@ -63,8 +63,9 @@ class ValidatedHTTPSConnection(HTTPSConnection):
             ).encode('ascii'))
             ca_certs.flush()
             cafile = ca_certs.name
-        self.sock = ssl.wrap_socket(sock, self.key_file, self.cert_file,
-                                    cert_reqs=ssl.CERT_REQUIRED,
-                                    ca_certs=cafile)
+        context = ssl.create_default_context()
+        if cafile:
+            context.load_verify_locations(cafile)
+        self.sock = context.wrap_socket(sock, server_hostname=self.host)
         if bundle is None:
             ca_certs.close()


### PR DESCRIPTION

File c:\Users\Ethan\Hobby\Rustle\.venv\Lib\site-packages\hetzner\robot.py:391, in ServerManager.__iter__(self)
    390 def __iter__(self):
--> 391     return iter([Server(self.conn, s) for s in self.conn.get('/server')])

File c:\Users\Ethan\Hobby\Rustle\.venv\Lib\site-packages\hetzner\robot.py:368, in RobotConnection.get(self, path)
    367 def get(self, path):
--> 368     return self.request('GET', path)

File c:\Users\Ethan\Hobby\Rustle\.venv\Lib\site-packages\hetzner\robot.py:329, in RobotConnection.request(self, method, path, data, allow_empty)
    325     headers['Content-Type'] = 'application/x-www-form-urlencoded'
    327 self.logger.debug("Sending %s request to Robot at %s with data %r.",
    328                   method, path, data)
--> 329 response = self._request(method, path, data, headers)
    330 raw_data = response.read().decode('utf-8')
    331 if len(raw_data) == 0 and not allow_empty:

File c:\Users\Ethan\Hobby\Rustle\.venv\Lib\site-packages\hetzner\robot.py:301, in RobotConnection._request(self, method, path, data, headers, retry)
    300 def _request(self, method, path, data, headers, retry=1):
...
     68                             ca_certs=cafile)
     69 if bundle is None:
     70     ca_certs.close()

AttributeError: module 'ssl' has no attribute 'wrap_socket'

Updated the SSL socket wrapping mechanism to use ssl.create_default_context() for improved security and maintainability. The previous method of wrapping the socket has been replaced with a context that loads verification locations if a CA file is provided.